### PR TITLE
Add support for variables of type string

### DIFF
--- a/conformance.adoc
+++ b/conformance.adoc
@@ -29,7 +29,8 @@ material required for completeness or clarity.
 
 *Requirements:*
 
-* CF attributes that take string values must be 1D character arrays.
+* CF attributes that take string values must be 1D character arrays or single
+atomic strings.
 
 [[section-1]]
 
@@ -352,10 +353,10 @@ blank separated list of variable names. All specified variable names
 must exist in the file.
 * The dimensions of each auxiliary coordinate must be a subset of the
 dimensions of the variable they are attached to, with two exceptions.
-First, a label variable which will have a trailing dimension for the
-maximum string length. Second a ragged array (Chapter 9, Discrete
-sampling geometries and Appendix H) uses special, more indirect, methods
-to connect the data and coordinates. +
+First, a label variable of type **`char`** will have a trailing dimension
+for the maximum string length.
+Second, a ragged array (Chapter 9, Discrete sampling geometries and Appendix H)
+uses special, more indirect, methods to connect the data and coordinates. +
 
 *Recommendations:*
 
@@ -408,11 +409,14 @@ the CRS WKT specification described in reference [OGC_CTS].
 
 *Requirements:*
 
-* A variable of character type that is named by a **`coordinates`** attribute
-is a label variable. This variable must have one or two dimensions. The
-trailing (CDL order) or sole dimension is for the maximum string length.
-If there are two dimensions, leading dimension (CDL order) must match
-one of those of the data variable.
+* A string variable that is named by a **`coordinates`** attribute is a label
+variable.
+If the variable is of type **`string`** it must have at most one dimension,
+which must match one of those of the data variable.
+If the variable is of type **`char`** it must have one or two dimensions, where
+the trailing (CDL order) or sole dimension is for the maximum string length.
+If there are two dimensions, the leading dimension (CDL order) must match one
+of those of the data variable.
 
 [[section-17]]
 
@@ -481,17 +485,23 @@ or more blank separated word lists, each with the form
 ....
 dim1: [dim2: [dim3: ...]] method [where type1 [over type2]] [within|over days|years] [(comment)]
 ....
-where brackets indicate optional words. The valid values for **`dim1`** [**`dim2`**
-[**`dim3`** ...] ] are the names of dimensions of the data variable, names of
-scalar coordinate variables of the data variable, valid standard names,
-or the word **`area`**. The valid values of **`method`** are contained in Appendix E. The valid values
-for **`type1`** are the name of a string-valued auxiliary  
-or scalar coordinate variable with a **`standard_name`** of **`area_type`**, or any
-string value allowed for a variable of **`standard_name`** of **`area_type`**. If
-**`type2`** is a string-valued auxiliary coordinate variable, it is not
-allowed to have a leading dimension (the number of strings) of more than
-one. When the method refers to a climatological time axis, the suffixes
-for within and over may be appended.
+where brackets indicate optional words.
+The valid values for **`dim1`** [**`dim2`** [**`dim3`** ...] ] are the names of
+dimensions of the data variable, names of scalar coordinate variables of the
+data variable, valid standard names, or the word **`area`**.
+The valid values of **`method`** are contained in Appendix E.
+The valid values for **`type1`** are the name of a string-valued auxiliary  or
+scalar coordinate variable with a **`standard_name`** of **`area_type`**, or
+any string value allowed for a variable of **`standard_name`** of
+**`area_type`**.
+If **`type2`** is a string-valued auxiliary coordinate variable, it must be
+sized to contain a single string.
+If it is a variable of type **`string`**, it must be scalar or one-dimensional
+with a length of one.
+If it is a variable of type **`char`**, it must be one-dimensional or
+two-dimensional with a leading dimension (the number of strings) of length one.
+When the method refers to a climatological time axis, the suffixes for within
+and over may be appended.
 
 * A given dimension name may only occur once in a **`cell_methods`** string.
 An exception is a climatological time dimension.


### PR DESCRIPTION
Expand the definition of a string variable to include variables of type **`string`** as well as those of type **`char`**.
See:
issue https://github.com/cf-convention/cf-conventions/issues/139
Trac ticket https://cf-trac.llnl.gov/trac/ticket/175#ticket
pull request https://github.com/cf-convention/cf-conventions/pull/140