### PR TITLE
Clarification that region and area_type variables may use flags

### DIFF
--- a/conformance.adoc
+++ b/conformance.adoc
@@ -190,8 +190,9 @@ name modifier.
 name table.
 * The legal values for the standard name modifier are contained in
 Appendix C, Standard Name Modifiers.
-* If a variable has a **`standard_name`** of **`region`** or **`area_type`**, it must have value(s) 
-from the permitted list.
+* If a variable has a **`standard_name`** of **`region`** or **`area_type`**,
+it must either have value(s) from the permitted list or, if flags are being used,
+the **`flag_meanings`** attribute must contain values from the permitted list.
 
 *Recommendataions:*
 


### PR DESCRIPTION
Update to bring Conformance doc in line with clarification to use of region names/area_types to allow  use of flag_values & flag_meanings as discussion in cf-convention/cf-conventions#198